### PR TITLE
Refactor AWS integration to rely on IAM role and Secrets Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,10 @@ ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0
 # DATABASE CONFIGURATION
 # =============================================================================
 # Local Development (PostgreSQL - Recommended)
-DATABASE_URL=postgresql://postgres:password@localhost:5432/watchparty_dev
+# Database credentials are retrieved from AWS Secrets Manager in production
+DATABASE_URL=postgresql://postgres@localhost:5432/watchparty_dev
 DB_NAME=watchparty_dev
 DB_USER=postgres
-DB_PASSWORD=password
 DB_HOST=localhost
 DB_PORT=5432
 
@@ -34,8 +34,8 @@ DB_PORT=5432
 # =============================================================================
 # REDIS CONFIGURATION
 # =============================================================================
+# Redis credentials are resolved via AWS Secrets Manager when deployed
 REDIS_URL=redis://localhost:6379/0
-REDIS_PASSWORD=redis123
 CELERY_BROKER_URL=redis://localhost:6379/2
 CELERY_RESULT_BACKEND=redis://localhost:6379/3
 CHANNEL_LAYERS_CONFIG_HOSTS=redis://localhost:6379/4
@@ -55,7 +55,6 @@ EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
 EMAIL_HOST=
 EMAIL_PORT=587
 EMAIL_HOST_USER=
-EMAIL_HOST_PASSWORD=
 EMAIL_USE_TLS=True
 DEFAULT_FROM_EMAIL=noreply@watchparty.com
 
@@ -75,8 +74,7 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 # =============================================================================
 # AWS S3 CONFIGURATION
 # =============================================================================
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+# Access keys are provided automatically by the MyAppRole IAM role
 AWS_STORAGE_BUCKET_NAME=
 AWS_S3_REGION_NAME=us-east-1
 AWS_S3_CUSTOM_DOMAIN=

--- a/apps/videos/tasks.py
+++ b/apps/videos/tasks.py
@@ -13,8 +13,9 @@ import tempfile
 import logging
 import json
 from typing import Optional, Dict, Any
-import boto3
 from botocore.exceptions import ClientError
+
+from shared.aws import get_boto3_session
 
 from .models import Video
 from apps.analytics.models import AnalyticsEvent
@@ -246,10 +247,8 @@ def upload_thumbnail_to_storage(thumbnail_path: str) -> Optional[str]:
 def upload_to_s3(file_path: str, s3_key: str) -> Optional[str]:
     """Upload file to AWS S3"""
     try:
-        s3_client = boto3.client(
+        s3_client = get_boto3_session().client(
             's3',
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION_NAME
         )
         

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -307,8 +307,6 @@ EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
 DEFAULT_FROM_EMAIL = config('DEFAULT_FROM_EMAIL', default='noreply@watchparty.com')
 
 # AWS S3 Configuration
-AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default='')
-AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default='')
 AWS_STORAGE_BUCKET_NAME = config('AWS_S3_BUCKET_NAME', default='')
 AWS_S3_REGION_NAME = config('AWS_S3_REGION_NAME', default='us-east-1')
 AWS_S3_FILE_OVERWRITE = False

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -166,5 +166,3 @@ class DisableMigrations:
 
 # Override any settings that might cause import errors
 USE_S3 = False
-AWS_ACCESS_KEY_ID = ''
-AWS_SECRET_ACCESS_KEY = ''

--- a/docs/deployment/SECRETS_GUIDE.md
+++ b/docs/deployment/SECRETS_GUIDE.md
@@ -24,7 +24,7 @@
 | Channels | CHANNEL_LAYERS_CONFIG_HOSTS | Redis layer URL | Secrets Manager | Yes |
 | Email | EMAIL_HOST, EMAIL_PORT, EMAIL_HOST_USER, EMAIL_HOST_PASSWORD, DEFAULT_FROM_EMAIL | SMTP | Secrets Manager / SSM | Optional |
 | Monitoring | SENTRY_DSN | Sentry DSN | Secrets Manager / GitHub | Optional |
-| Storage | AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_STORAGE_BUCKET_NAME | S3 media (if enabled) | Use IAM role or Secrets Manager | Optional |
+| Storage | AWS_STORAGE_BUCKET_NAME | S3 media (if enabled) | IAM role (MyAppRole) | Optional |
 | Social / APIs | GOOGLE_OAUTH2_CLIENT_ID, GOOGLE_OAUTH2_CLIENT_SECRET, YOUTUBE_API_KEY, TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET | Third party APIs | Secrets Manager | As used |
 | Security | RATE_LIMIT_* (if dynamic), any API tokens | Runtime config | SSM | Optional |
 | Deployment | SSH_PRIVATE_KEY | SSH to server (only if push model) | GitHub Secrets | Yes (if used) |
@@ -52,6 +52,11 @@ Recommended single JSON secret (example key: `watchparty/production/core`):
 }
 ```
 Additional secrets (API keys) can live in `watchparty/production/integrations`.
+
+### Standard Secret Names
+
+- `all-in-one-credentials` – contains database connection details and related service URLs.
+- `watch-party-valkey-001-auth-token` – stores the Valkey/Redis authentication token when one is required.
 
 ### Naming Convention
 ```

--- a/docs/deployment/github-secrets-template.txt
+++ b/docs/deployment/github-secrets-template.txt
@@ -74,9 +74,8 @@ DEFAULT_FROM_EMAIL=noreply@brahim-elhouss.me
 # =============================================================================
 # AWS S3 (OPTIONAL)
 # =============================================================================
+# Credentials are provided automatically by the MyAppRole IAM role
 USE_S3=False
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
 AWS_STORAGE_BUCKET_NAME=
 AWS_S3_REGION_NAME=us-east-1
 

--- a/docs/development/integrations.md
+++ b/docs/development/integrations.md
@@ -40,11 +40,13 @@ GOOGLE_DRIVE_CLIENT_SECRET=your_google_client_secret
 GOOGLE_SERVICE_ACCOUNT_FILE=/path/to/service_account.json
 
 # AWS S3 Configuration
-AWS_ACCESS_KEY_ID=your_aws_access_key
-AWS_SECRET_ACCESS_KEY=your_aws_secret_key
 AWS_STORAGE_BUCKET_NAME=your_s3_bucket
 AWS_S3_REGION_NAME=us-east-1
 AWS_S3_CUSTOM_DOMAIN=your_cloudfront_domain.cloudfront.net
+
+# Secrets Manager
+# Database/Redis credentials: all-in-one-credentials
+# Valkey token: watch-party-valkey-001-auth-token
 
 # Social OAuth Providers
 GOOGLE_OAUTH_CLIENT_ID=your_google_oauth_client_id
@@ -91,7 +93,7 @@ python manage.py setup_integrations
 ### 4. AWS S3 Setup
 
 1. Create S3 bucket in AWS Console
-2. Create IAM user with S3 permissions
+2. Attach the `MyAppRole` IAM role to your compute resources (EC2, ECS, etc.) and grant it the required S3 permissions (`s3:GetObject`, `s3:PutObject`)
 3. (Optional) Set up CloudFront distribution
 4. Configure CORS policy:
 

--- a/scripts/deployment/github-actions-setup.sh
+++ b/scripts/deployment/github-actions-setup.sh
@@ -184,8 +184,7 @@ GITHUB_OAUTH_CLIENT_SECRET=your-github-client-secret
 # =============================================================================
 # AWS SETTINGS (OPTIONAL - for S3 storage)
 # =============================================================================
-AWS_ACCESS_KEY_ID=your-aws-access-key
-AWS_SECRET_ACCESS_KEY=your-aws-secret-key
+# Credentials come from the MyAppRole IAM role attached to the runner
 AWS_STORAGE_BUCKET_NAME=your-s3-bucket
 AWS_S3_REGION_NAME=us-east-1
 

--- a/scripts/deployment/set-github-secrets.sh
+++ b/scripts/deployment/set-github-secrets.sh
@@ -79,8 +79,7 @@ declare -A DEPLOYMENT_SECRETS=(
     ["DEFAULT_FROM_EMAIL"]="noreply@brahim-elhouss.me"
     # AWS S3
     ["USE_S3"]="False"
-    ["AWS_ACCESS_KEY_ID"]=""
-    ["AWS_SECRET_ACCESS_KEY"]=""
+    # Credentials provided by MyAppRole IAM role
     ["AWS_STORAGE_BUCKET_NAME"]=""
     ["AWS_S3_REGION_NAME"]="us-east-1"
     # Security
@@ -348,8 +347,6 @@ check_missing_deployment_secrets() {
         "GOOGLE_OAUTH_CLIENT_SECRET"
         "GITHUB_OAUTH_CLIENT_ID"
         "GITHUB_OAUTH_CLIENT_SECRET"
-        "AWS_ACCESS_KEY_ID"
-        "AWS_SECRET_ACCESS_KEY"
     )
     
     for secret in "${optional_secrets[@]}"; do

--- a/scripts/development/env-setup.sh
+++ b/scripts/development/env-setup.sh
@@ -354,8 +354,7 @@ STRIPE_SECRET_KEY=sk_test_placeholder
 STRIPE_WEBHOOK_SECRET=whsec_placeholder
 
 # AWS S3 Configuration (for file storage)
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+# Credentials are supplied by the MyAppRole IAM role in AWS
 AWS_STORAGE_BUCKET_NAME=
 AWS_S3_REGION_NAME=us-east-1
 AWS_S3_CUSTOM_DOMAIN=
@@ -560,8 +559,7 @@ STRIPE_SECRET_KEY=sk_live_your_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 
 # AWS S3 Configuration
-AWS_ACCESS_KEY_ID=your_aws_access_key_id
-AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+# Credentials are provided via the MyAppRole IAM role
 AWS_STORAGE_BUCKET_NAME=watchparty-prod-media
 AWS_S3_REGION_NAME=us-east-1
 AWS_S3_CUSTOM_DOMAIN=$backend_domain

--- a/scripts/development/env-validator.sh
+++ b/scripts/development/env-validator.sh
@@ -148,7 +148,6 @@ validate_required_vars() {
     # Check optional but important variables
     local optional_vars=(
         "SENTRY_DSN"
-        "AWS_ACCESS_KEY_ID"
         "GOOGLE_OAUTH_CLIENT_ID"
         "YOUTUBE_API_KEY"
     )
@@ -431,8 +430,6 @@ MEDIA_URL=/media/
 
 # Optional: Third-party Services
 # SENTRY_DSN=
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
 # GOOGLE_OAUTH_CLIENT_ID=
 # GOOGLE_OAUTH_CLIENT_SECRET=
 # YOUTUBE_API_KEY=

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -459,9 +459,6 @@ STATIC_URL=/static/
 # CSRF_COOKIE_SECURE=True
 
 # Third-party services
-# AWS_ACCESS_KEY_ID=your-aws-access-key
-# AWS_SECRET_ACCESS_KEY=your-aws-secret-key
-# AWS_STORAGE_BUCKET_NAME=your-bucket-name
 
 # Social Authentication
 # GOOGLE_OAUTH_CLIENT_ID=your-google-client-id

--- a/shared/aws.py
+++ b/shared/aws.py
@@ -1,0 +1,87 @@
+"""Utilities for interacting with AWS services using the project's IAM role.
+
+This module centralizes the creation of boto3 sessions and helpers for
+retrieving secrets from AWS Secrets Manager.  The helpers intentionally avoid
+accepting static access keys so that the application always relies on the
+attached IAM role (MyAppRole).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+LOGGER = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def get_boto3_session() -> boto3.Session:
+    """Return a cached boto3 session that relies on the IAM role credentials."""
+
+    return boto3.Session()
+
+
+def _decode_secret_payload(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Decode the payload returned by ``get_secret_value`` into a dictionary."""
+
+    if "SecretString" in response and response["SecretString"]:
+        try:
+            return json.loads(response["SecretString"])
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            LOGGER.warning("Secret string is not valid JSON: %s", exc)
+            return {"value": response["SecretString"]}
+
+    if "SecretBinary" in response and response["SecretBinary"]:
+        decoded = base64.b64decode(response["SecretBinary"])
+        try:
+            return json.loads(decoded)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            LOGGER.warning("Secret binary is not valid JSON: %s", exc)
+            return {"value": decoded.decode("utf-8")}
+
+    return {}
+
+
+@lru_cache(maxsize=None)
+def get_secret(secret_name: str, *, region: str = "eu-west-3") -> Dict[str, Any]:
+    """Fetch and cache a secret from AWS Secrets Manager.
+
+    Parameters
+    ----------
+    secret_name:
+        Name or ARN of the secret to retrieve.
+    region:
+        AWS region that hosts the secret. Defaults to ``eu-west-3`` to align
+        with the shared environment configuration.
+
+    Returns
+    -------
+    dict
+        Parsed secret payload. For JSON secrets this will be the decoded
+        dictionary. If the payload cannot be decoded as JSON it falls back to
+        a dictionary containing the raw value under the ``"value"`` key.
+    """
+
+    try:
+        client = get_boto3_session().client("secretsmanager", region_name=region)
+        response = client.get_secret_value(SecretId=secret_name)
+    except (ClientError, BotoCoreError) as exc:
+        LOGGER.error("Unable to retrieve secret '%s': %s", secret_name, exc)
+        raise
+
+    return _decode_secret_payload(response)
+
+
+def get_optional_secret(secret_name: str, *, region: str = "eu-west-3") -> Optional[Dict[str, Any]]:
+    """Return the secret payload if it can be fetched, otherwise ``None``."""
+
+    try:
+        return get_secret(secret_name, region=region)
+    except (ClientError, BotoCoreError):
+        return None

--- a/shared/management/commands/setup_integrations.py
+++ b/shared/management/commands/setup_integrations.py
@@ -147,8 +147,8 @@ class Command(BaseCommand):
             'name': 'default',
             'bucket_name': getattr(settings, 'AWS_STORAGE_BUCKET_NAME', ''),
             'region': getattr(settings, 'AWS_S3_REGION_NAME', 'us-east-1'),
-            'access_key_id': getattr(settings, 'AWS_ACCESS_KEY_ID', ''),
-            'secret_access_key': getattr(settings, 'AWS_SECRET_ACCESS_KEY', ''),
+            'access_key_id': '',  # IAM role provides credentials automatically
+            'secret_access_key': '',
             'cloudfront_domain': getattr(settings, 'AWS_S3_CUSTOM_DOMAIN', ''),
             'use_cloudfront': bool(getattr(settings, 'AWS_S3_CUSTOM_DOMAIN', '')),
             'max_file_size': 5368709120,  # 5GB


### PR DESCRIPTION
## Summary
- add a shared AWS utility module that provides the boto3 session and Secrets Manager helpers
- update configuration, background tasks, and deployment assets to drop static AWS credentials in favour of IAM role access
- document the new secret names and refresh environment templates with Secrets Manager guidance

## Testing
- python -m compileall shared apps/videos/tasks.py
- python -m compileall shared/database_optimization.py

------
https://chatgpt.com/codex/tasks/task_b_68d6831c81408328913aebd93961cf15