### PR TITLE
Add Next.js frontend planning documentation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -38,6 +38,12 @@ This directory contains all organized documentation for the Watch Party Backend 
 - Contributing guidelines
 - Code standards
 
+### 🧩 **frontend/** - Next.js Implementation Guides
+- [`nextjs-pages-and-components.md`](frontend/nextjs-pages-and-components.md) - Pages, layouts, and shared components
+- [`api-integration-guide.md`](frontend/api-integration-guide.md) - REST and realtime integration patterns
+- [`user-admin-scenarios.md`](frontend/user-admin-scenarios.md) - User journeys and admin workflows
+- [`technology-alignment.md`](frontend/technology-alignment.md) - Mapping backend tech to frontend usage
+
 ### 🔍 **maintenance/** - System Maintenance
 - System monitoring
 - Backup procedures

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,12 @@ Welcome to the Watch Party Backend documentation. This directory contains compre
 - **[DEPLOYMENT.md](deployment/DEPLOYMENT.md)** - Complete deployment guide
 - **[GITHUB_ACTIONS_UPDATE.md](deployment/GITHUB_ACTIONS_UPDATE.md)** - CI/CD and GitHub Actions setup
 
+### 🧩 Frontend Documentation (`/frontend/`)
+- **[Next.js Pages & Components](frontend/nextjs-pages-and-components.md)** - Required routes and shared UI inventory
+- **[API Integration Guide](frontend/api-integration-guide.md)** - How the frontend communicates with the backend
+- **[User & Admin Scenarios](frontend/user-admin-scenarios.md)** - End-to-end experience flows
+- **[Technology Alignment](frontend/technology-alignment.md)** - How to use backend tech from Next.js
+
 ### 🛠️ Development Documentation (`/development/`)
 - **[ERD.md](development/ERD.md)** - Entity Relationship Diagram and database schema
 - **[integrations.md](development/integrations.md)** - Third-party integrations guide

--- a/docs/frontend/api-integration-guide.md
+++ b/docs/frontend/api-integration-guide.md
@@ -1,0 +1,106 @@
+# Frontend ↔ Backend Integration Guide
+
+This guide explains how the Next.js frontend communicates with the Watch Party backend. It covers REST conventions, authentication, pagination, realtime channels, and client utilities.
+
+## Base Configuration
+
+- **API Base URL**: `${process.env.NEXT_PUBLIC_API_BASE_URL}/api`
+- **WebSocket Base URL**: `${process.env.NEXT_PUBLIC_WS_BASE_URL}/ws`
+- **Authentication**: JSON Web Tokens (JWT) issued by `/api/auth/login/` and refreshed via `/api/auth/refresh/`.
+- **Content Type**: `application/json` (multipart for uploads).
+- **Pagination**: Cursor-based with `page`, `page_size`, and optional `cursor` parameters as described in [`docs/api/backend-endpoints.json`](../api/backend-endpoints.json).
+
+Create a central API client in `lib/api-client.ts`:
+
+```ts
+export const apiClient = {
+  async get<T>(path: string, options?: RequestInit) {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api${path}`, {
+      ...options,
+      method: 'GET',
+      headers: await withAuthHeaders(options?.headers),
+      next: { revalidate: 0 },
+    });
+    return parseResponse<T>(res);
+  },
+  async post<T>(path: string, body?: unknown, options?: RequestInit) {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api${path}`, {
+      ...options,
+      method: 'POST',
+      headers: await withAuthHeaders({ 'Content-Type': 'application/json', ...options?.headers }),
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return parseResponse<T>(res);
+  },
+  // implement patch/delete similarly
+};
+```
+
+`withAuthHeaders` reads the JWT access token from cookies or NextAuth session. Refresh tokens are stored in `httpOnly` cookies and exchanged using Next.js Route Handlers (`app/api/auth/refresh/route.ts`).
+
+## Authentication Flows
+
+1. **Login** (`POST /api/auth/login/`)
+   - Body: `{ "email": string, "password": string }`
+   - Response: `{ access: string, refresh: string, user: {...} }`
+   - Frontend stores `access` in memory (e.g., Zustand store) and `refresh` in `httpOnly` cookie via a server action.
+2. **Register** (`POST /api/auth/register/`)
+   - Provide profile fields defined in `apps/users/serializers.py` (username, email, password, profile data).
+3. **Two-Factor** (`POST /api/auth/verify-2fa/`) when required by `apps/authentication` policies.
+4. **Session Refresh** (`POST /api/auth/refresh/`) automatically invoked by the `AuthProvider` when TanStack Query receives a `401`.
+
+## Core Feature Endpoints
+
+| Feature | Endpoint | Notes |
+|---------|----------|-------|
+| Watch Parties | `GET /api/parties/` | List parties the user hosts or attends; use query params `status`, `cursor`.
+| Create Party | `POST /api/parties/` | Submit payload matching `WatchPartyCreateSerializer` including `title`, `scheduled_for`, `video` reference, `settings`.
+| Party Detail | `GET /api/parties/{partyId}/` | Includes participants, chat summary, polls.
+| Party Invitations | `POST /api/parties/{partyId}/invite/` | Send invites; expect `emails` array.
+| Party Analytics | `GET /api/analytics/parties/{partyId}/` | Power the dashboard analytics page.
+| Realtime Sync | WebSocket `ws/party/{partyId}/` | Join with JWT in query string `?token=` or `Authorization` header via protocols.
+| Chat Threads | `GET /api/chat/threads/` | Cursor pagination; use `MessagingThread` component.
+| Messages | `GET /api/chat/threads/{threadId}/messages/` & `POST` for sending.
+| Videos | `GET /api/videos/` | Upload uses multipart `POST /api/videos/upload/`; track progress with `VideoProcessingJob` status polling (`/api/videos/{id}/processing/`).
+| Events | `GET /api/events/` | Filter with `?from`, `?to`, `?type` for calendar.
+| Notifications | `GET /api/notifications/` | Use `PATCH /api/notifications/{id}/read/` to mark as read.
+| Store | `GET /api/store/products/` | Purchases via `POST /api/store/checkout/`.
+| Billing | `GET /api/billing/subscription/` | Manage plan, `POST /api/billing/upgrade/`.
+| Support | `POST /api/support/tickets/` | Attachments via multipart; follow-up updates `POST /api/support/tickets/{id}/reply/`.
+| Admin Users | `GET /api/admin/users/` | Provide `role`, `status`, `search` filters.
+| Moderation | `GET /api/moderation/reports/` & `POST /api/moderation/reports/{id}/resolve/`.
+
+Refer to serializers and viewsets under `apps/*/api` for payload shape.
+
+## Data Fetching Strategy
+
+- **Server Components**: Use `cache: 'no-store'` for personalized data; leverage React Suspense for parallel fetches in `app/(dashboard)/page.tsx`.
+- **TanStack Query**: Wrap client components with `QueryProvider`. Define keys per resource (e.g., `['parties', { status, cursor }]`).
+- **Optimistic Updates**: For actions like message send or notification mark-as-read, update query cache immediately and roll back if mutation fails.
+- **Error Handling**: Normalize API errors using backend standard `{ "detail": string }` or serializer error maps.
+
+## File Uploads
+
+- Use `next-safe-middleware` to allow video uploads only from authorized roles.
+- For large uploads, request pre-signed URL via `/api/videos/upload-url/` before uploading directly to storage.
+- Track processing status by polling `/api/videos/{id}/` until `processing_state === 'ready'` or subscribing to `ws/party/{partyId}/` events that emit `video_ready`.
+
+## Realtime Channels
+
+- **Party Sync**: `ws://.../ws/party/{partyId}/` for playback position, reactions.
+- **Chat**: `ws://.../ws/chat/{partyId}/` for in-party messages.
+- **Notifications**: `ws://.../ws/notifications/` for toast updates.
+- **Interactive Widgets**: Polls, screen share, and voice chat routes defined in [`apps/interactive/routing.py`](../../apps/interactive/routing.py).
+
+The frontend should create a `WebSocketProvider` that handles connection lifecycle, authentication (JWT as query param), reconnection with exponential backoff, and dispatches events to Zustand stores.
+
+## Rate Limiting & Retries
+
+- The backend enforces throttling on endpoints like `/api/auth/login/` and `/api/parties/{id}/invite/`. Catch `429` responses and show retry countdowns.
+- Use `Retry-After` header for scheduling retries. TanStack Query's retry logic should respect this header.
+
+## Testing Requests
+
+- Use MSW (Mock Service Worker) to simulate backend endpoints during Storybook and Playwright runs.
+- Provide fixtures aligned with backend serializers (see `tests/` directory for JSON examples).
+

--- a/docs/frontend/api-integration-guide.md
+++ b/docs/frontend/api-integration-guide.md
@@ -59,16 +59,16 @@ export const apiClient = {
 | Party Invitations | `POST /api/parties/{partyId}/invite/` | Send invites; expect `emails` array.
 | Party Analytics | `GET /api/analytics/parties/{partyId}/` | Power the dashboard analytics page.
 | Realtime Sync | WebSocket `ws/party/{partyId}/` | Join with JWT in query string `?token=` or `Authorization` header via protocols.
-| Chat Threads | `GET /api/chat/threads/` | Cursor pagination; use `MessagingThread` component.
-| Messages | `GET /api/chat/threads/{threadId}/messages/` & `POST` for sending.
+| Conversations | `GET /api/messaging/conversations/` | Cursor pagination; use `MessagingThread` component.
+| Party Chat Messages | `GET /api/chat/{partyId}/messages/` & `POST /api/chat/{partyId}/messages/send/` for sending.
 | Videos | `GET /api/videos/` | Upload uses multipart `POST /api/videos/upload/`; track progress with `VideoProcessingJob` status polling (`/api/videos/{id}/processing/`).
 | Events | `GET /api/events/` | Filter with `?from`, `?to`, `?type` for calendar.
 | Notifications | `GET /api/notifications/` | Use `PATCH /api/notifications/{id}/read/` to mark as read.
-| Store | `GET /api/store/products/` | Purchases via `POST /api/store/checkout/`.
+| Store | `GET /api/store/items/` | Purchases via `POST /api/store/purchase/`.
 | Billing | `GET /api/billing/subscription/` | Manage plan, `POST /api/billing/upgrade/`.
-| Support | `POST /api/support/tickets/` | Attachments via multipart; follow-up updates `POST /api/support/tickets/{id}/reply/`.
+| Support | `POST /api/support/tickets/` | Attachments via multipart; follow-up updates `POST /api/support/tickets/{id}/messages/`.
 | Admin Users | `GET /api/admin/users/` | Provide `role`, `status`, `search` filters.
-| Moderation | `GET /api/moderation/reports/` & `POST /api/moderation/reports/{id}/resolve/`.
+| Moderation | `GET /api/moderation/reports/` & `POST /api/moderation/admin/reports/{id}/resolve/`.
 
 Refer to serializers and viewsets under `apps/*/api` for payload shape.
 

--- a/docs/frontend/nextjs-pages-and-components.md
+++ b/docs/frontend/nextjs-pages-and-components.md
@@ -1,0 +1,123 @@
+# Next.js Frontend Pages and Component Inventory
+
+This document enumerates every page and shared component required for the Watch Party frontend. The application will be implemented with the Next.js App Router and TypeScript.
+
+## Directory Overview
+
+```
+app/
+├─ (marketing)/
+│  ├─ page.tsx                # Landing
+│  ├─ pricing/page.tsx        # Pricing + plans
+│  └─ features/page.tsx       # Feature overview
+├─ (auth)/
+│  ├─ login/page.tsx          # Email/password & social login
+│  ├─ register/page.tsx       # Registration flow
+│  ├─ reset-password/page.tsx # Reset request + update
+│  └─ verify-email/[token]/page.tsx
+├─ (dashboard)/
+│  ├─ layout.tsx
+│  ├─ page.tsx                # Personalized feed & quick actions
+│  ├─ watch-parties/
+│  │  ├─ create/page.tsx
+│  │  ├─ [partyId]/page.tsx   # Live party room shell
+│  │  ├─ [partyId]/settings/page.tsx
+│  │  └─ archive/page.tsx     # Past parties
+│  ├─ videos/
+│  │  ├─ upload/page.tsx
+│  │  ├─ library/page.tsx
+│  │  └─ [videoId]/page.tsx
+│  ├─ events/
+│  │  ├─ page.tsx
+│  │  ├─ create/page.tsx
+│  │  └─ [eventId]/page.tsx
+│  ├─ messages/
+│  │  ├─ page.tsx             # Conversation list
+│  │  └─ [threadId]/page.tsx
+│  ├─ notifications/page.tsx
+│  ├─ store/page.tsx
+│  ├─ analytics/page.tsx
+│  ├─ settings/
+│  │  ├─ profile/page.tsx
+│  │  ├─ account/page.tsx
+│  │  ├─ security/page.tsx
+│  │  └─ preferences/page.tsx
+│  └─ support/
+│     ├─ page.tsx             # Help center
+│     └─ tickets/[ticketId]/page.tsx
+└─ (admin)/
+   ├─ layout.tsx
+   ├─ page.tsx                # Admin overview
+   ├─ users/page.tsx
+   ├─ moderation/page.tsx
+   ├─ analytics/page.tsx
+   ├─ support/page.tsx
+   ├─ billing/page.tsx
+   └─ system/page.tsx
+```
+
+## Shared Component Library
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `TopNav` | `components/navigation/top-nav.tsx` | Authenticated navigation with notifications, search, quick actions.
+| `SideNav` | `components/navigation/side-nav.tsx` | Contextual navigation (user dashboard or admin tools).
+| `MarketingHeader` | `components/marketing/header.tsx` | Hero header with CTA buttons.
+| `Footer` | `components/marketing/footer.tsx` | Global footer, legal links, app download.
+| `AuthCard` | `components/auth/auth-card.tsx` | Form card used for login/register/reset.
+| `Input`, `Select`, `Textarea` | `components/forms/` | Standardized form inputs integrated with React Hook Form.
+| `Button`, `IconButton` | `components/ui/buttons.tsx` | Primary and secondary action buttons.
+| `DataTable` | `components/data/table.tsx` | Paginated table supporting cursor pagination from the backend.
+| `FilterBar` | `components/data/filter-bar.tsx` | Quick filters and saved views.
+| `EmptyState` | `components/ui/empty-state.tsx` | Placeholder state for empty lists.
+| `Modal`, `Drawer`, `Popover` | `components/ui/overlays.tsx` | Shared overlay primitives.
+| `ToastProvider` | `components/feedback/toast-provider.tsx` | Notification toasts wired to mutation status.
+| `Avatar`, `UserBadge` | `components/user/` | User presentation components with status indicator.
+| `PartyPlayer` | `components/party/player.tsx` | Video player synced via WebSocket + HLS.
+| `PartyChat` | `components/party/chat.tsx` | Realtime chat room with message reactions.
+| `PartySidebar` | `components/party/sidebar.tsx` | Participants list, polls, reactions.
+| `PollWidget` | `components/party/poll-widget.tsx` | Poll creation & participation UI.
+| `ScreenSharePanel` | `components/party/screen-share-panel.tsx` | Host controls for screen sharing.
+| `EventCard` | `components/events/event-card.tsx` | List item for events calendar.
+| `Calendar` | `components/events/calendar.tsx` | Calendar view for events & watch parties.
+| `VideoUploader` | `components/videos/video-uploader.tsx` | Upload widget with progress + transcoding status.
+| `VideoDetail` | `components/videos/video-detail.tsx` | Video metadata, analytics summary.
+| `MessagingThread` | `components/messaging/thread.tsx` | Conversation view with infinite scroll.
+| `NotificationList` | `components/notifications/notification-list.tsx` | Notification center with filters.
+| `StoreProductCard` | `components/store/product-card.tsx` | Store items, currency purchase.
+| `AnalyticsCharts` | `components/analytics/charts.tsx` | Wrapper around charting library (Recharts or Chart.js).
+| `BillingSummary` | `components/billing/summary.tsx` | Subscription status & invoices.
+| `SupportTicketForm` | `components/support/ticket-form.tsx` | Form to submit support tickets.
+| `AdminStats` | `components/admin/admin-stats.tsx` | KPIs for admin landing page.
+| `AdminUserTable` | `components/admin/user-table.tsx` | Manage users with moderation actions.
+| `AdminModerationQueue` | `components/admin/moderation-queue.tsx` | Review content reports & actions.
+| `SystemHealthWidget` | `components/admin/system-health-widget.tsx` | Surface monitoring metrics.
+
+## Layout & Providers
+
+- `app/layout.tsx`: Global `<html>` shell, theme provider, font imports.
+- `app/(auth)/layout.tsx`: Minimal layout for auth forms.
+- `app/(dashboard)/layout.tsx`: Authenticated shell with `TopNav` and `SideNav`.
+- `app/(admin)/layout.tsx`: Admin shell with additional guard.
+- `components/providers/`:
+  - `AuthProvider` (hooks into NextAuth or custom JWT refresh flow).
+  - `QueryProvider` (TanStack Query hydration for server components).
+  - `WebSocketProvider` (party, chat, notifications realtime updates).
+  - `ThemeProvider` (light/dark toggle, persisted via cookies).
+
+## Routing Guards
+
+- Middleware in `middleware.ts` to enforce auth and role-based routing.
+- Server components fetch user session via cookies and gate server actions.
+
+## Server Actions & Mutations
+
+- Use Next.js server actions for secure mutations where possible (e.g., profile updates) and fallback to API routes when real-time feedback is needed.
+- Co-locate mutations inside feature directories, e.g., `app/(dashboard)/watch-parties/actions.ts`.
+
+## Testing & Storybook Coverage
+
+- Storybook stories under `stories/` for each component above.
+- Playwright component tests for real-time components (PartyChat, PartyPlayer) using mocked WebSocket server.
+- Integration tests for auth, dashboard, and admin flows using Next.js testing utilities.
+

--- a/docs/frontend/technology-alignment.md
+++ b/docs/frontend/technology-alignment.md
@@ -1,0 +1,80 @@
+# Technology Alignment: Using Backend Capabilities from Next.js
+
+This reference explains how the Next.js frontend should leverage backend technologies exposed by the Watch Party platform.
+
+## Django REST Framework (DRF)
+
+- All REST endpoints conform to DRF viewsets/serializers (see [`config/urls.py`](../../config/urls.py)).
+- Expect consistent envelope: success responses provide resource payloads, validation errors return serializer error maps.
+- Use TypeScript types generated from the backend OpenAPI schema (`/api/schema/` via drf-spectacular). Generate types with `openapi-typescript` and store in `@types/generated`.
+
+## SimpleJWT Authentication
+
+- Access tokens: short-lived, stored in memory and forwarded via `Authorization: Bearer` header.
+- Refresh tokens: long-lived, stored securely in `httpOnly` cookies. Next.js Route Handlers call `/api/auth/refresh/` to rotate tokens.
+- Handle token rotation in a server action to avoid exposing refresh tokens to the client bundle.
+
+## Django Channels WebSockets
+
+- Channels routes defined in [`apps/chat/routing.py`](../../apps/chat/routing.py), [`apps/interactive/routing.py`](../../apps/interactive/routing.py), and [`apps/parties/routing.py`](../../apps/parties/routing.py).
+- Use native `WebSocket` API or libraries like `@microsoft/signalr`-style wrappers to connect, passing JWT via query string or custom header `Sec-WebSocket-Protocol: Bearer,<token>`.
+- Implement exponential backoff reconnection and presence tracking aligned with `PartyConsumer` events.
+
+## Celery & Async Tasks
+
+- Video processing, analytics aggregation, and notification dispatch run asynchronously via Celery workers (`start-celery-worker.sh`).
+- Frontend should poll or subscribe to status endpoints such as `/api/videos/{id}/processing/` and `/api/analytics/jobs/{id}/` to reflect Celery job progress.
+- Display user feedback (spinners/toasts) until `status` transitions to `completed` or `failed`.
+
+## Redis & Caching
+
+- Realtime features rely on Redis through `channels_redis`. Frontend must be resilient to transient disconnects.
+- Cached endpoints may expose `ETag`/`Last-Modified`. Use `If-None-Match` headers when available to minimize bandwidth.
+
+## Stripe Billing
+
+- Billing endpoints (e.g., `/api/billing/checkout/`) integrate with Stripe per [`apps/billing`](../../apps/billing/).
+- Frontend initiates Stripe Checkout via the publishable key in `NEXT_PUBLIC_STRIPE_KEY` and uses session IDs returned from the backend.
+- Handle webhooks indirectly: backend notifies frontend via notifications WebSocket when payment status changes.
+
+## Firebase & Push Notifications
+
+- The backend manages Firebase Admin for push notifications (`apps/notifications`).
+- Frontend web app should register service workers using Firebase Web SDK and send registration tokens to `/api/notifications/push-subscriptions/`.
+- Display fallback browser notifications for unsupported clients.
+
+## Analytics Pipeline
+
+- Analytics events captured through `/api/analytics/events/` and real-time party analytics endpoints.
+- Debounce client-side analytics dispatch to avoid spamming Celery tasks; batch events where supported (`POST` array payloads).
+- Align event names with `AnalyticsEvent` model defined in [`apps/analytics/models.py`](../../apps/analytics/models.py).
+
+## Search Infrastructure
+
+- Search endpoints under `/api/search/` likely backed by Elastic/OpenSearch (check `apps/search`).
+- Provide instant-search UI with debounced requests and highlight results based on `SearchResult` schema.
+- For advanced filters, inspect serializer filters in `apps/search/api.py` to mirror facets on the frontend.
+
+## Third-Party Integrations
+
+- Google/Firebase: Use tokens or configuration served from `/api/integrations/google/config/` to initialize client SDKs lazily.
+- Social Auth: For social logins, the backend exposes OAuth redirect URLs. Implement Next.js route handler proxies to start flows without exposing backend secrets.
+- Streaming Providers: Some parties use external streaming via `/api/integrations/providers/`. Render provider-specific components when `integration.type` indicates Twitch, YouTube, etc.
+
+## Monitoring & Sentry
+
+- Backend emits Sentry events; align frontend error reporting by initializing `@sentry/nextjs` with matching DSN.
+- Include breadcrumbs correlating to API requests to aid cross-service debugging.
+
+## Environment Management
+
+- Store runtime config in `.env.local`; mirror backend required variables (`NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_WS_BASE_URL`, `NEXT_PUBLIC_STRIPE_KEY`, `FIREBASE_CONFIG_*`).
+- During Vercel deploy, configure environment groups that match backend staging/production clusters.
+
+## Local Development
+
+1. Start backend via `./start-django.sh` or `docker-compose`.
+2. Run websocket server (`./start-daphne.sh`) if testing realtime flows.
+3. Launch frontend `pnpm dev` with proxies for `/api` and `/ws` to backend ports (use Next.js rewrites in `next.config.js`).
+4. Seed demo data using backend fixtures (`python manage.py loaddata demo`).
+

--- a/docs/frontend/technology-alignment.md
+++ b/docs/frontend/technology-alignment.md
@@ -17,7 +17,7 @@ This reference explains how the Next.js frontend should leverage backend technol
 ## Django Channels WebSockets
 
 - Channels routes defined in [`apps/chat/routing.py`](../../apps/chat/routing.py), [`apps/interactive/routing.py`](../../apps/interactive/routing.py), and [`apps/parties/routing.py`](../../apps/parties/routing.py).
-- Use native `WebSocket` API or libraries like `@microsoft/signalr`-style wrappers to connect, passing JWT via query string or custom header `Sec-WebSocket-Protocol: Bearer,<token>`.
+- Use the native `WebSocket` API or compatible libraries (e.g., `ws`, `@tanstack/query`) to connect, passing JWT via query string or custom header `Sec-WebSocket-Protocol: Bearer,<token>`.
 - Implement exponential backoff reconnection and presence tracking aligned with `PartyConsumer` events.
 
 ## Celery & Async Tasks

--- a/docs/frontend/user-admin-scenarios.md
+++ b/docs/frontend/user-admin-scenarios.md
@@ -1,0 +1,85 @@
+# Frontend User & Admin Experience Scenarios
+
+This document outlines end-to-end scenarios the Next.js frontend must support for both end users and administrators. Each scenario references relevant pages from the [structure guide](./nextjs-pages-and-components.md) and backend touchpoints from the [integration guide](./api-integration-guide.md).
+
+## Personas
+
+- **Host**: Runs watch parties, uploads videos, manages invitations.
+- **Participant**: Joins parties, chats, reacts, purchases items.
+- **Content Creator**: Focused on video uploads, analytics, monetization.
+- **Administrator**: Oversees platform health, moderation, billing, support.
+
+## User Scenarios
+
+### 1. First-Time Visitor → Registered Host
+1. Visit marketing landing (`/(marketing)`).
+2. Explore pricing, click **Get Started**.
+3. Register via `/(auth)/register` (POST `/api/auth/register/`).
+4. Verify email using link hitting `/(auth)/verify-email/[token]`.
+5. Log in `/(auth)/login` (POST `/api/auth/login/`).
+6. Redirect to dashboard home `/(dashboard)`; load stats via `GET /api/dashboard/stats/`.
+7. Complete profile in `/(dashboard)/settings/profile` (PATCH `/api/users/me/`).
+
+### 2. Create and Host a Watch Party
+1. From dashboard home, click **Create Party**.
+2. `/(dashboard)/watch-parties/create` displays form prefilled with video library data (`GET /api/videos/?status=ready`).
+3. Submit form (`POST /api/parties/`).
+4. On success, redirect to party settings `/(dashboard)/watch-parties/[partyId]/settings` to configure moderation toggles (`PATCH /api/parties/{id}/settings/`).
+5. Send invitations using party sidebar (modal uses `POST /api/parties/{id}/invite/`).
+6. At scheduled time, navigate to live room `/(dashboard)/watch-parties/[partyId]`.
+7. `PartyPlayer` connects to `ws/party/{partyId}/` for playback sync; `PartyChat` joins `ws/chat/{partyId}/`.
+8. Host can trigger polls (`POST /api/interactive/polls/`) and screen share (WebRTC handshake via interactive WebSocket endpoints).
+
+### 3. Participant Joins from Invitation
+1. Receives invitation email linking to `/(auth)/login?next=/join/party/{partyId}`.
+2. After login, join page fetches party metadata (`GET /api/parties/{id}/`) and ensures access.
+3. Participant enters lobby `ws/party/{id}/lobby/` for readiness, then transitions into party.
+4. Interacts via chat, reactions, polls, and purchases merch from store sidebar (`POST /api/store/checkout/`).
+
+### 4. Creator Uploads Video & Reviews Analytics
+1. Navigate to `/(dashboard)/videos/upload`.
+2. Upload file; request pre-signed URL (`POST /api/videos/upload-url/`) and direct-upload.
+3. Poll `GET /api/videos/{id}/` until `processing_state` is `ready`.
+4. Video appears in library `/(dashboard)/videos/library`.
+5. View analytics in `/(dashboard)/analytics` using `GET /api/analytics/videos/{id}/` and aggregated metrics from `/api/analytics/overview/`.
+
+### 5. Support Ticket Submission
+1. From dashboard `Need Help?` link to `/(dashboard)/support`.
+2. Submit new ticket (`POST /api/support/tickets/`).
+3. Receive updates via notifications (WebSocket `ws/notifications/`) and view conversation in `/(dashboard)/support/tickets/[ticketId]`.
+
+## Admin Scenarios
+
+### A. Platform Overview & Moderation
+1. Admin signs in (`/(auth)/login` → `role === admin`).
+2. Redirect to admin home `/(admin)`.
+3. Dashboard loads KPIs using `GET /api/admin/overview/` & `/api/analytics/platform/`.
+4. Navigate to moderation queue `/(admin)/moderation`; fetch reports via `GET /api/moderation/reports/`.
+5. Review flagged content using embedded video/player components.
+6. Take action with `POST /api/moderation/reports/{id}/resolve/` or escalate to suspension (`POST /api/moderation/users/{userId}/suspend/`).
+7. Changes broadcast to affected users through notifications WebSocket.
+
+### B. User Management & Support
+1. Admin opens `/(admin)/users`; `AdminUserTable` calls `GET /api/admin/users/?search=`.
+2. View detailed profile in modal `GET /api/admin/users/{id}/`.
+3. Adjust roles or reset MFA via `PATCH /api/admin/users/{id}/`.
+4. Switch to support tab `/(admin)/support`; join active ticket threads (`GET /api/support/tickets/?status=open`).
+5. Respond directly using admin reply endpoint `POST /api/support/tickets/{id}/respond/`.
+
+### C. Billing Oversight
+1. Go to `/(admin)/billing`.
+2. Fetch subscription summary (`GET /api/billing/admin/summary/`) and invoice history (`GET /api/billing/invoices/`).
+3. Trigger refunds or manual adjustments via `POST /api/billing/invoices/{id}/refund/`.
+
+### D. System Health Monitoring
+1. Navigate to `/(admin)/system`.
+2. Display logs from `/api/admin/system/logs/` and performance metrics from `/api/analytics/system/`.
+3. Provide quick links to backend health endpoints: `/api/health/`, `/api/test/`, `/api/docs/`.
+
+## Cross-Cutting Concerns
+
+- **Access Control**: `middleware.ts` checks `session.role` to route between `(dashboard)` and `(admin)` segments.
+- **Global Notifications**: Toasts triggered by WebSocket `notification` events; fallback polling `/api/notifications/unread-count/`.
+- **Offline Support**: Cache marketing pages statically; degrade party experience with recorded video playback if realtime fails.
+- **Internationalization**: Use `next-intl` with namespaces per page to match backend localization keys.
+

--- a/docs/frontend/user-admin-scenarios.md
+++ b/docs/frontend/user-admin-scenarios.md
@@ -28,13 +28,13 @@ This document outlines end-to-end scenarios the Next.js frontend must support fo
 5. Send invitations using party sidebar (modal uses `POST /api/parties/{id}/invite/`).
 6. At scheduled time, navigate to live room `/(dashboard)/watch-parties/[partyId]`.
 7. `PartyPlayer` connects to `ws/party/{partyId}/` for playback sync; `PartyChat` joins `ws/chat/{partyId}/`.
-8. Host can trigger polls (`POST /api/interactive/polls/`) and screen share (WebRTC handshake via interactive WebSocket endpoints).
+8. Host can trigger polls (`POST /api/interactive/parties/{partyId}/polls/create/`) and screen share (WebRTC handshake via interactive WebSocket endpoints).
 
 ### 3. Participant Joins from Invitation
 1. Receives invitation email linking to `/(auth)/login?next=/join/party/{partyId}`.
 2. After login, join page fetches party metadata (`GET /api/parties/{id}/`) and ensures access.
 3. Participant enters lobby `ws/party/{id}/lobby/` for readiness, then transitions into party.
-4. Interacts via chat, reactions, polls, and purchases merch from store sidebar (`POST /api/store/checkout/`).
+4. Interacts via chat, reactions, polls, and purchases merch from store sidebar (`POST /api/store/purchase/`).
 
 ### 4. Creator Uploads Video & Reviews Analytics
 1. Navigate to `/(dashboard)/videos/upload`.
@@ -56,7 +56,7 @@ This document outlines end-to-end scenarios the Next.js frontend must support fo
 3. Dashboard loads KPIs using `GET /api/admin/overview/` & `/api/analytics/platform/`.
 4. Navigate to moderation queue `/(admin)/moderation`; fetch reports via `GET /api/moderation/reports/`.
 5. Review flagged content using embedded video/player components.
-6. Take action with `POST /api/moderation/reports/{id}/resolve/` or escalate to suspension (`POST /api/moderation/users/{userId}/suspend/`).
+6. Take action with `POST /api/moderation/admin/reports/{id}/resolve/` or escalate to suspension (`POST /api/moderation/users/{userId}/suspend/`).
 7. Changes broadcast to affected users through notifications WebSocket.
 
 ### B. User Management & Support
@@ -64,7 +64,7 @@ This document outlines end-to-end scenarios the Next.js frontend must support fo
 2. View detailed profile in modal `GET /api/admin/users/{id}/`.
 3. Adjust roles or reset MFA via `PATCH /api/admin/users/{id}/`.
 4. Switch to support tab `/(admin)/support`; join active ticket threads (`GET /api/support/tickets/?status=open`).
-5. Respond directly using admin reply endpoint `POST /api/support/tickets/{id}/respond/`.
+5. Respond directly using admin reply endpoint `POST /api/support/tickets/{id}/messages/`.
 
 ### C. Billing Oversight
 1. Go to `/(admin)/billing`.


### PR DESCRIPTION
## Summary
- add a dedicated frontend documentation section covering structure, API integration, scenarios, and technology alignment
- document required Next.js pages/components and end-to-end user and admin flows tied to backend endpoints
- update the documentation index and README to reference the new frontend guides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68d903b08e1883289787afee93f598c6